### PR TITLE
feat(print): quote non-status string replies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ tags
 
 
 # End of https://www.gitignore.io/api/go,vim,macos,code
+
+/bin/

--- a/redis-connect.go
+++ b/redis-connect.go
@@ -104,7 +104,11 @@ func printResult(res interface{}, err error, prefix string) {
 	case int64:
 		fmt.Printf("(integer) %d\n", res)
 	case string:
-		fmt.Printf("%s\n", res)
+		if res == "OK" || res == "QUEUED" || res == "PONG" {
+			fmt.Printf("%s\n", res)
+		} else {
+			fmt.Printf("%q\n", res)
+		}
 	case []interface{}:
 		if len(res) == 0 {
 			fmt.Println("(empty list or set)")


### PR DESCRIPTION
## What & Why
Quote strings, excluding status replies (`"OK"`, `"QUEUED"`, `"PONG"`), on replies. 

There doesn't seem to be a way to easily extract the type of response (error, status, int, string, array) using [go-redis](https://github.com/go-redis/redis) however there are only 3 types of string replies that are statuses so we can check against these values for now. 

There is a known bug with this approach in that an actual string response of `OK`, `QUEUED` or `PONG` will not be printed with quotes in if it actually needed to be (such as in the event of a non-status command).